### PR TITLE
Handle each overlap in only one biclique

### DIFF
--- a/inc/PileupGenerator.hpp
+++ b/inc/PileupGenerator.hpp
@@ -74,6 +74,14 @@ public:
             OverlapMap& overlaps,
             HandleGraph& graph,
             PoaPileup& pileup);
+    
+    // Do POA with spoa for an arbitrary collection of edges
+    static void generate_spoa_graph_from_edges(
+            const vector<edge_t>& edges,
+            const IncrementalIdMap<string>& id_map,
+            OverlapMap& overlaps,
+            HandleGraph& graph,
+            PoaPileup& pileup);
 
     // A generator-style DFS walk of the nodes in the partition
     static bool traverse_bipartition_nodes(


### PR DESCRIPTION
Refactor SPOA interface to allow subsets of a biclique to be used instead of all edges. Use the new interface to handle each overlap in only one biclique.