### PR TITLE
CLI and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # GetBlunted
-For bluntifying overlapped GFAs
+
+For converting GFAs with overlapped sequences into blunt-ended GFAs, with no overlaps.
 
 ## Method
+
 Overlaps are resolved using POA, as in the following diagram:
 ![POA alignment](https://github.com/rlorigro/GetBlunted/blob/dev/images/overlap_poa_diagram.svg)
 
-The adjacency of nodes (as described by the Link lines in the GFA) is preserved. In particular, cases in which adjacency components are not fully connected (case C), new paths are **not** introduced between unlinked nodes. This is achieved by computing a biclique cover for each adjacency component and creating branches in the terminus of any node which participates in multiple bicliques.
+The way that we resolve overlaps is designed to provide two guarantees. First, all two-hop adjacencies are preserved (i.e. if `A > B > C` is a walk in the input, that walk will be preserved in the output). This is the extent of adjacency information described in the link lines of the GFA. Second, no single-hop adjacencies are created that are not present in the input. False single-hop adjacencies are a risk when merged overlapped sequences in adjacency components are not fully connected (case C). To accomplish these two goals, it is somtimes necessary to duplicate portions of input sequences in the output. A table describing the provenance of the output sequences can optionally be produced alongside the output GFA.
 ![Diploid examples](https://github.com/rlorigro/GetBlunted/blob/dev/images/example_bluntification_cases.svg)
 
 ## Usage
 
-```./GetBlunted /path/to/input.gfa```
+```./get_blunted [-p provenance_table.txt] input.gfa > bluntified.gfa```
 
 For a typical phased human assembly GFA (5.1GB) about 8GB of RAM are used, and run time is 1m 30s.
 
 ## Installation
 
-GetBlunted is compatible with Ubuntu (tested on 18.04) and MacOS
+GetBlunted is compatible with Ubuntu (tested on 18.04) and MacOS (tested on 10.14.6)
 
 External dependencies: `libomp`, `cmake`
 

--- a/inc/Bluntifier.hpp
+++ b/inc/Bluntifier.hpp
@@ -17,6 +17,7 @@
 #include "spoa/graph.hpp"
 
 #include <unordered_map>
+#include <ctime>
 
 #include "bdsg/hash_graph.hpp"
 
@@ -46,6 +47,9 @@ class Bluntifier {
 private:
     /// Attributes ///
     string gfa_path;
+    string provenance_path;
+    bool verbose;
+    time_t time_start;
 
     HashGraph gfa_graph;
     IncrementalIdMap<string> id_map;
@@ -73,11 +77,13 @@ private:
 
 public:
     /// Methods ///
-    Bluntifier(string gfa_path);
+    Bluntifier(const string& gfa_path,
+               const string& provenance_path,
+               bool verbose);
 
     void bluntify();
 
-    void write_provenance(string& output_path);
+    void write_provenance();
 
 private:
     void deduplicate_and_canonicalize_biclique_cover(
@@ -118,6 +124,8 @@ private:
             edge_t& canonical_edge,
             edge_t& edge,
             nid_t child_id);
+    
+    void log_progress(const string& msg) const;
 };
 
 

--- a/inc/handle_to_gfa.hpp
+++ b/inc/handle_to_gfa.hpp
@@ -8,7 +8,7 @@ using handlegraph::HandleGraph;
 using handlegraph::handle_t;
 using handlegraph::edge_t;
 using std::runtime_error;
-using std::ofstream;
+using std::ostream;
 using std::string;
 
 
@@ -18,14 +18,14 @@ namespace bluntifier {
 char get_reversal_character(const HandleGraph& graph, const handle_t& node);
 
 
-void write_node_to_gfa(const HandleGraph& graph, const handle_t& node, ofstream& output_file);
+void write_node_to_gfa(const HandleGraph& graph, const handle_t& node, ostream& output_file);
 
 
-void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ofstream& output_file);
+void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ostream& output_file);
 
 
 /// With no consideration for directionality, just dump all the edges/nodes into GFA format
-void handle_graph_to_gfa(const HandleGraph& graph, const string& output_path);
+void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa);
 
 
 // TODO write this method to use the overlaps and id map to write the linkages/sequences in the canonical direction

--- a/src/executable/get_blunted.cpp
+++ b/src/executable/get_blunted.cpp
@@ -1,22 +1,107 @@
 #include "Bluntifier.hpp"
 
-using bluntifier::Bluntifier;
+#include <iostream>
+#include <getopt.h>
 
+using bluntifier::Bluntifier;
+using std::ifstream;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+void print_usage() {
+    cerr << "usage: get_blunted [options] overlap_graph.gfa > blunt_graph.gfa" << endl;
+    cerr << endl;
+    cerr << "options:" << endl;
+    cerr << " -p, --provenance FILEPATH track origin of bluntified sequences in a table here" << endl;
+    cerr << " -V, --verbose             log progress to stderr during execution" << endl;
+    cerr << " -v, --version             print the version to stdout and exit" << endl;
+    cerr << " -h, --help                print this help message to stderr and exit" << endl;
+}
+
+void print_version() {
+    cout << "get_blunted version 0.0.1" << endl;
+}
 
 int main(int argc, char **argv){
-    string gfa_path;
-
-    if (argc == 1){
-        throw runtime_error("No input gfa path provided");
+    
+    string provenance_path;
+    bool verbose = false;
+    
+    int c;
+    while (true){
+        static struct option long_options[] =
+        {
+            {"provenance", required_argument, 0, 'p'},
+            {"verbose", no_argument, 0, 'V'},
+            {"version", no_argument, 0, 'v'},
+            {"help", no_argument, 0, 'h'},
+            {0,0,0,0}
+        };
+        
+        int option_index = 0;
+        c = getopt_long (argc, argv, "p:Vvh",
+                         long_options, &option_index);
+        if (c == -1){
+            break;
+        }
+        
+        switch(c){
+            case 'p':
+                provenance_path = optarg;
+                break;
+            case 'V':
+                verbose = true;
+                break;
+            case 'v':
+                print_version();
+                return 0;
+            case 'h':
+            case '?':
+                print_usage();
+                return 0;
+            default:
+                print_usage();
+                return 1;
+        }
     }
-    else if (argc == 2){
-        gfa_path = argv[1];
+    
+    if (optind >= argc) {
+        // no positional arguments
+        cerr << "ERROR: overlap GFA file is required" << endl;
+        print_usage();
+        return 1;
     }
-    else{
-        throw runtime_error("Too many arguments. Specify 1 input gfa path.");
+    
+    string gfa_path = argv[optind];
+    ++optind;
+    
+    if (optind < argc) {
+        // arguments are included past the positional argument
+        
+        cerr << "ERROR: unused argument(s):" << endl;
+        while (optind < argc) {
+            cerr << "\t" << argv[optind] << endl;
+            ++optind;
+        }
+        return 1;
     }
-
-    Bluntifier bluntifier(gfa_path);
+    
+    // test input for openability
+    if (!ifstream(gfa_path)) {
+        cerr << "ERROR: could not open input GFA " << gfa_path << endl;
+        return 1;
+    }
+    
+    if (verbose) {
+        cerr << "[get_blunted] Executing command:";
+        for (int i = 0; i < argc; ++i) {
+            cerr << ' ' << argv[i];
+        }
+        cerr << endl;
+    }
+    
+    Bluntifier bluntifier(gfa_path, provenance_path, verbose);
     bluntifier.bluntify();
 
     return 0;

--- a/src/executable/get_blunted.cpp
+++ b/src/executable/get_blunted.cpp
@@ -13,10 +13,10 @@ void print_usage() {
     cerr << "usage: get_blunted [options] overlap_graph.gfa > blunt_graph.gfa" << endl;
     cerr << endl;
     cerr << "options:" << endl;
-    cerr << " -p, --provenance FILEPATH track origin of bluntified sequences in a table here" << endl;
-    cerr << " -V, --verbose             log progress to stderr during execution" << endl;
-    cerr << " -v, --version             print the version to stdout and exit" << endl;
-    cerr << " -h, --help                print this help message to stderr and exit" << endl;
+    cerr << " -p, --provenance FILEPATH   track origin of bluntified sequences in a table here" << endl;
+    cerr << " -V, --verbose               log progress to stderr during execution" << endl;
+    cerr << " -v, --version               print the version to stdout and exit" << endl;
+    cerr << " -h, --help                  print this help message to stderr and exit" << endl;
 }
 
 void print_version() {

--- a/src/handle_to_gfa.cpp
+++ b/src/handle_to_gfa.cpp
@@ -16,12 +16,12 @@ char get_reversal_character(const HandleGraph& graph, const handle_t& node){
 }
 
 
-void write_node_to_gfa(const HandleGraph& graph, const handle_t& node, ofstream& output_file){
+void write_node_to_gfa(const HandleGraph& graph, const handle_t& node, ostream& output_file){
     output_file << "S\t" << graph.get_id(node) << '\t' << graph.get_sequence(node) << '\n';
 }
 
 
-void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ofstream& output_file){
+void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ostream& output_file){
     output_file << "L\t" << graph.get_id(edge.first) << '\t' << get_reversal_character(graph, edge.first) << '\t'
                 << graph.get_id(edge.second) << '\t' << get_reversal_character(graph, edge.second) << '\t'
                 << "0M" << '\n';
@@ -29,14 +29,7 @@ void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ofstream& o
 
 
 /// With no consideration for directionality, just dump all the edges/nodes into GFA format
-void handle_graph_to_gfa(const HandleGraph& graph, const string& output_path){
-    std::cerr << "Writing GFA to file: " << output_path << '\n';
-
-    ofstream output_gfa(output_path);
-
-    if (not output_gfa.good()){
-        throw runtime_error("ERROR: output file could not be written: " + output_path);
-    }
+void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa){
 
     output_gfa << "H\tHVN:Z:1.0\n";
 
@@ -53,8 +46,9 @@ void handle_graph_to_gfa(const HandleGraph& graph, const string& output_path){
 // TODO write this method to use the overlaps and id map to write the linkages/sequences in the canonical direction
 // using the canonical names as well, wherever possible
 void handle_graph_to_canonical_gfa(const HandleGraph& graph, const string& output_path){
-    ofstream output_gfa(output_path);
 
+    assert(false);
+//    ofstream output_gfa(output_path);
 //    graph.for_each_handle([&](handle_t& node){
 //
 //    });

--- a/src/test/test_divide_handle.cpp
+++ b/src/test/test_divide_handle.cpp
@@ -2,12 +2,15 @@
 #include "handle_to_gfa.hpp"
 #include "bdsg/hash_graph.hpp"
 
+#include <iostream>
+
 using bluntifier::handle_graph_to_gfa;
 using bluntifier::run_command;
 using bdsg::HashGraph;
 
 using std::string;
 using std::vector;
+using std::ofstream;
 
 int main(){
 
@@ -21,7 +24,8 @@ int main(){
 
         {
             string test_path_prefix = "test_divide_handle" + std::to_string(o);
-            handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+            ofstream out(test_path_prefix + ".gfa");
+            handle_graph_to_gfa(graph, out);
             string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                              + test_path_prefix + ".png";
             run_command(command);

--- a/src/test/test_duplicate_terminus.cpp
+++ b/src/test/test_duplicate_terminus.cpp
@@ -4,6 +4,8 @@
 #include "handle_to_gfa.hpp"
 #include "bdsg/hash_graph.hpp"
 
+#include <iostream>
+
 using bluntifier::duplicate_prefix;
 using bluntifier::duplicate_suffix;
 using bluntifier::handle_graph_to_gfa;
@@ -13,6 +15,7 @@ using bdsg::HashGraph;
 
 using std::string;
 using std::deque;
+using std::ofstream;
 
 
 void test_adjacent_same_lengths_prefix(){
@@ -30,7 +33,8 @@ void test_adjacent_same_lengths_prefix(){
 
     {
         string test_path_prefix = "test_adjacent_same_lengths_prefix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -40,7 +44,8 @@ void test_adjacent_same_lengths_prefix(){
 
     {
         string test_path_prefix = "test_adjacent_same_lengths_prefix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -79,7 +84,8 @@ void test_single_value_prefix(){
 
     {
         string test_path_prefix = "test_single_value_prefix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -89,7 +95,8 @@ void test_single_value_prefix(){
 
     {
         string test_path_prefix = "test_single_value_prefix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -129,7 +136,8 @@ void test_zero_value_prefix(){
 
     {
         string test_path_prefix = "test_zero_value_prefix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -139,7 +147,8 @@ void test_zero_value_prefix(){
 
     {
         string test_path_prefix = "test_zero_value_prefix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -178,7 +187,8 @@ void test_full_length_value_prefix(){
 
     {
         string test_path_prefix = "test_full_length_value_prefix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -188,7 +198,8 @@ void test_full_length_value_prefix(){
 
     {
         string test_path_prefix = "test_full_length_value_prefix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -231,7 +242,8 @@ void test_adjacent_same_lengths_suffix(){
 
     {
         string test_path_prefix = "test_adjacent_same_lengths_suffix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -241,7 +253,8 @@ void test_adjacent_same_lengths_suffix(){
 
     {
         string test_path_prefix = "test_adjacent_same_lengths_suffix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -280,7 +293,8 @@ void test_single_value_suffix(){
 
     {
         string test_path_prefix = "test_single_value_suffix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -290,7 +304,8 @@ void test_single_value_suffix(){
 
     {
         string test_path_prefix = "test_single_value_suffix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -330,7 +345,8 @@ void test_zero_value_suffix(){
 
     {
         string test_path_prefix = "test_zero_value_suffix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -340,7 +356,8 @@ void test_zero_value_suffix(){
 
     {
         string test_path_prefix = "test_zero_value_suffix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -379,7 +396,8 @@ void test_full_length_value_suffix(){
 
     {
         string test_path_prefix = "test_full_length_value_suffix_" + std::to_string(0);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);
@@ -389,7 +407,8 @@ void test_full_length_value_suffix(){
 
     {
         string test_path_prefix = "test_full_length_value_suffix_" + std::to_string(1);
-        handle_graph_to_gfa(graph, test_path_prefix + ".gfa");
+        ofstream out(test_path_prefix + ".gfa");
+        handle_graph_to_gfa(graph, out);
         string command = "vg convert -g " + test_path_prefix + ".gfa -p | vg view -d - | dot -Tpng -o "
                          + test_path_prefix + ".png";
         run_command(command);

--- a/src/test/test_handle_to_gfa.cpp
+++ b/src/test/test_handle_to_gfa.cpp
@@ -8,6 +8,7 @@
 using handlegraph::handle_t;
 using bdsg::PackedGraph;
 using std::ifstream;
+using std::ofstream;
 
 using bluntifier::gfa_to_path_handle_graph_in_memory;
 using bluntifier::gfa_to_path_handle_graph;
@@ -38,7 +39,8 @@ int main(){
 
     string output_dir = join_paths(project_directory, "data/");
     string output_path = join_paths(output_dir, "handle_to_gfa_test_output.gfa");
-    handle_graph_to_gfa(g, output_path);
+    ofstream out(output_path);
+    handle_graph_to_gfa(g, out);
 
     return 0;
 }


### PR DESCRIPTION
I implemented a cleaner CLI without any hard-coded paths, along with some simple options and option parsing using `optparse`. I also revised the description of the method in the README.