### PR TITLE
No longer crash on graphs with reversing self edges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,17 +281,18 @@ include(ExternalProject)
 
 if(dev)
 #    # Download or update library as an external project
-#    ExternalProject_Add(project_abPOA
-#            GIT_REPOSITORY https://github.com/yangao07/abPOA.git
-#            GIT_TAG bfe4ac0a4945ed3eadf68282776fc816b299947e
-#            DOWNLOAD_COMMAND ""
-#            UPDATE_COMMAND ""
-#            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-#            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/abPOA/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/abPOA/lib
-#            BUILD_IN_SOURCE True
-#            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/abPOA/
-#            INSTALL_COMMAND make install
-#            )
+# Download or update library as an external project
+    ExternalProject_Add(project_kalign
+            GIT_REPOSITORY https://github.com/TimoLassmann/kalign.git
+            GIT_TAG 58ca06a51b53d76d3fb96ef335fbc7110c36cd46
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/kalign/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/kalign/lib
+            BUILD_IN_SOURCE True
+            INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/kalign/
+            INSTALL_COMMAND make install
+            )
 else()
     # Download or update library as an external project
     ExternalProject_Add(project_kalign
@@ -303,7 +304,6 @@ else()
             INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/kalign/
             INSTALL_COMMAND make install
             )
-
 endif()
 
 # Define INSTALL_DIR as the install directory for external library
@@ -344,7 +344,7 @@ if(dev)
     # Download or update library as an external project
     ExternalProject_Add(project_bdsg
             GIT_REPOSITORY https://github.com/vgteam/libbdsg-easy.git
-            GIT_TAG b989949811918b18de48a5e57d7f45473d8901f1
+            GIT_TAG abe12120bbbbc0127c69de7cc01e925001a0c922
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
             CONFIGURE_COMMAND ""
             DOWNLOAD_COMMAND ""
@@ -357,7 +357,7 @@ else()
     # Download or update library as an external project
     ExternalProject_Add(project_bdsg
             GIT_REPOSITORY https://github.com/vgteam/libbdsg-easy.git
-            GIT_TAG b989949811918b18de48a5e57d7f45473d8901f1
+            GIT_TAG abe12120bbbbc0127c69de7cc01e925001a0c922
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
             CONFIGURE_COMMAND ""
             BUILD_IN_SOURCE True
@@ -421,10 +421,11 @@ if(dev)
     # Download or update library as an external project
     ExternalProject_Add(project_spoa
             GIT_REPOSITORY https://github.com/rvaser/spoa.git
+            GIT_TAG 1ab9ab076171e5e4f5fcd4d2a2369f26c7f8f48f
             DOWNLOAD_COMMAND ""
             UPDATE_COMMAND ""
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib -DCMAKE_BUILD_TYPE=Release
             BUILD_IN_SOURCE True
             INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/spoa/
             INSTALL_COMMAND make install
@@ -434,8 +435,9 @@ else()
     # Download or update library as an external project
     ExternalProject_Add(project_spoa
             GIT_REPOSITORY https://github.com/rvaser/spoa.git
+            GIT_TAG 1ab9ab076171e5e4f5fcd4d2a2369f26c7f8f48f
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/external/spoa/ -DCMAKE_INSTALL_LIBDIR=${CMAKE_SOURCE_DIR}/external/spoa/lib -DCMAKE_BUILD_TYPE=Release
             BUILD_IN_SOURCE True
             INSTALL_DIR ${CMAKE_SOURCE_DIR}/external/spoa/
             INSTALL_COMMAND make install

--- a/src/AdjacencyComponent.cpp
+++ b/src/AdjacencyComponent.cpp
@@ -440,6 +440,7 @@ void AdjacencyComponent::decompose_into_bipartite_blocks(const function<void(con
     
     bipartition partition = bipartite_partition();
     if (partition.first.size() + partition.second.size() == component.size()) {
+
         // the whole component is bipartite, so there is only need for the one bipartite block
         lambda(BipartiteGraph(*graph, partition));
     }
@@ -447,11 +448,11 @@ void AdjacencyComponent::decompose_into_bipartite_blocks(const function<void(con
         // TODO: magic constants
         if (component.size() < 8) {
             // the case is small enough to solve with brute force
-            partition = exhaustive_maximum_bipartite_partition();
+            partition = move(exhaustive_maximum_bipartite_partition());
         }
         else {
             // start off with an approximate bipartition
-            partition = maximum_bipartite_partition_apx_1_2();
+            partition = move(maximum_bipartite_partition_apx_1_2());
             
             // first iteration bound heuristically derived from Kaul & West (2008)
             size_t max_opt_iters = min<size_t>(ceil(0.5 * pow(component.size(), 1.5)),

--- a/src/Bluntifier.cpp
+++ b/src/Bluntifier.cpp
@@ -161,6 +161,7 @@ void Bluntifier::compute_biclique_cover(size_t i){
     }
 
     adjacency_component.decompose_into_bipartite_blocks([&](const BipartiteGraph& bipartite_graph){
+        
         vector <bipartition> biclique_cover = BicliqueCover(bipartite_graph).get();
         vector <vector <edge_t> > deduplicated_biclique_cover;
 

--- a/src/ReducedDualGraph.cpp
+++ b/src/ReducedDualGraph.cpp
@@ -21,7 +21,7 @@ using std::stable_sort;
 ReducedDualGraph::ReducedDualGraph(const BipartiteGraph& graph) : graph(&graph) {
     
 #ifdef debug_dual_graph
-    cerr << "constructing dual graph" << endl;
+    cerr << "constructing dual graph for bipartite graph with left size " << graph.left_size() << ", right size " << graph.right_size() << endl;
 #endif
     
     // make a local, mutable copy of the bipartite graph and init

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -102,7 +102,7 @@ void gfa_to_handle_graph_in_memory(
             }
             if (b == graph.flip(a)) {
                 if (num_self_overlap_warnings++ < max_num_self_overlap_warnings) {
-                    cerr << "WARNING: skipping overlap that reverses back onto the same sequence (in de Bruijn graphs, these can be avoided by choosing an odd-numbered overlap length): " << e.source_name << '\n';
+                    cerr << "WARNING: skipping overlap that reverses back onto the same sequence (in de Bruijn graphs, these can be avoided by choosing an odd-numbered overlap length): " << edge.source_name << '\n';
                 }
                 if (num_self_overlap_warnings == max_num_self_overlap_warnings) {
                     cerr << "suppressing further warnings\n";

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -59,6 +59,8 @@ void gfa_to_handle_graph_in_memory(
     }
 
     // create edges
+    size_t num_self_overlap_warnings = 0;
+    size_t max_num_self_overlap_warnings = 10;
     for (const auto& links_record : gg.get_seq_to_edges()) {
         for (const auto& edge : links_record.second) {
             validate_gfa_edge(edge);
@@ -80,8 +82,7 @@ void gfa_to_handle_graph_in_memory(
             // note: we're counting on implementations de-duplicating edges
             handle_t a = graph.get_handle(source_id, not edge.source_orientation_forward);
             handle_t b = graph.get_handle(sink_id, not edge.sink_orientation_forward);
-            graph.create_edge(a, b);
-
+            
             // Update the overlap map
             Alignment alignment(edge.alignment);
 
@@ -97,6 +98,15 @@ void gfa_to_handle_graph_in_memory(
             if (lengths.second > graph.get_length(b)){
                 cerr << "WARNING: skipping overlap for which sum of cigar operations is > SINK node length: "
                      << edge.source_name << "->" << edge.sink_name << '\n' << '\n';
+                valid = false;
+            }
+            if (b == graph.flip(a)) {
+                if (num_self_overlap_warnings++ < max_num_self_overlap_warnings) {
+                    cerr << "WARNING: skipping overlap that reverses back onto the same sequence (in de Bruijn graphs, these can be avoided by choosing an odd-numbered overlap length): " << e.source_name << '\n';
+                }
+                if (num_self_overlap_warnings == max_num_self_overlap_warnings) {
+                    cerr << "suppressing further warnings\n";
+                }
                 valid = false;
             }
 
@@ -142,6 +152,8 @@ void gfa_to_handle_graph_on_disk(
     });
 
     // add in all edges
+    size_t num_self_overlap_warnings = 0;
+    size_t max_num_self_overlap_warnings = 10;
     gg.for_each_edge_line_in_file(const_cast<char*>(filename.c_str()), [&](gfak::edge_elem e) {
         validate_gfa_edge(e);
 
@@ -176,6 +188,15 @@ void gfa_to_handle_graph_on_disk(
         if (lengths.second > graph.get_length(b)){
             cerr << "WARNING: skipping overlap for which sum of cigar operations is > SINK node length: "
                  << e.source_name << "->" << e.sink_name << '\n' << '\n';
+            valid = false;
+        }
+        if (b == graph.flip(a)) {
+            if (num_self_overlap_warnings++ < max_num_self_overlap_warnings) {
+                cerr << "WARNING: skipping overlap that reverses back onto the same sequence (in de Bruijn graphs, these can be avoided by choosing an odd-numbered overlap length): " << e.source_name << '\n';
+            }
+            if (num_self_overlap_warnings == max_num_self_overlap_warnings) {
+                cerr << "suppressing further warnings\n";
+            }
             valid = false;
         }
 


### PR DESCRIPTION
Our algorithm can't handle reversing self-edges, because they can't be included in any bipartite graph. The solution implemented here is just to filter these edges out, which is not fully satisfactory. In the case where we encountered this bug, the self-edges were caused by palindromic overlaps in a compacted de Bruijn graph. This issue could be avoided by the typical practice of choosing odd-length overlaps for the DBG so that there are no palindromes. 

Resolves https://github.com/vgteam/GetBlunted/issues/52.